### PR TITLE
Fixed invokations on methods on non-generic classes, and execution on generic methods inside generic classes

### DIFF
--- a/ILAttributesUnity/Assets/ILAttributes/CodeGen/GenericTypeConverter.cs
+++ b/ILAttributesUnity/Assets/ILAttributes/CodeGen/GenericTypeConverter.cs
@@ -11,10 +11,11 @@ namespace ILAttributes.CodeGen
         //  TypeDefinition typeDefinition;
         // Collection<GenericParameter> genericParametersOfType;
         Collection<GenericParameter> genericParametersOfTypeDef;
+		public Collection<GenericParameter> GenericParametersOfMethod;
 
         //  Collection<GenericParameter> genericParametersOfMethod;
-        //  Collection<GenericParameter> genericParametersOfMethodDeclaringType;
-        public bool IsGenericInstance => genericParametersOfTypeDef != null;
+		//  Collection<GenericParameter> genericParametersOfMethodDeclaringType;
+		public bool IsGenericInstance => genericParametersOfTypeDef != null;
 
         public int GenericParameterCount => genericParametersOfTypeDef?.Count ?? 0;
 
@@ -139,16 +140,27 @@ namespace ILAttributes.CodeGen
             if (typeReference.IsGenericParameter)
             {
                 var genericParameter = (GenericParameter)typeReference;
-                foreach (var defGenericParameter in genericParametersOfTypeDef)
+                foreach ( var defGenericParameter in genericParametersOfTypeDef )
                 {
                     if (defGenericParameter.Name == genericParameter.Name)
                         return defGenericParameter;
                 }
 
-                throw new NotSupportedException("GenericParameter of GenericClass is not supported" +
-                                                genericParameter.Name);
-                //return typeReference;
-            }
+				//
+				if (GenericParametersOfMethod is null)
+					throw new NotSupportedException("GenericParameter of GenericClass is not supported");
+
+				var gpPos = genericParameter.Position - genericParametersOfTypeDef.Count;
+				if ( gpPos >= GenericParametersOfMethod.Count )
+					throw new NotSupportedException($"GenericParameter position is out of range: {genericParameter.Position} for {genericParameter.Name} out of / {GenericParametersOfMethod.Count} params." );
+
+				if ( gpPos < 0 )
+					throw new NotSupportedException( $"GenericParameter position is negative: {genericParameter.Position} for {genericParameter.Name} out of / {GenericParametersOfMethod.Count} params." );
+				
+				return GenericParametersOfMethod[gpPos] ??
+				       throw new NotSupportedException( "GenericParametersOfMethod gpPos offset is incorrect / not supported for type arg: " +
+						genericParameter.Name );
+			}
 
             if (typeReference.IsGenericInstance)
             {


### PR DESCRIPTION
This was quite a weird situation and I understand why it was broken. But this should solve the issue once and for all.
All my personal tests are passing and other than that great library man!

I also have made a local fix for nested generic types, for example
[ILUnsafeAccessor( ILUnsafeAccessorKind.Field, "_entries", typeof( Dictionary<,> ), "/Entry" )]
private static extern ref DictEntry<TKey, TValue>[] GetEntries<TKey, TValue>( Dictionary<TKey, TValue> instance );

But the solution is a bit messy and not up to standards, let me know if you want to take a look!